### PR TITLE
feat: Add rich Scribble gesture support with DeltaTextInputClient

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -429,10 +429,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -610,10 +610,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/editor/config/editor_config.dart
+++ b/lib/src/editor/config/editor_config.dart
@@ -81,6 +81,7 @@ class QuillEditorConfig {
     this.requestKeyboardFocusOnCheckListChanged = false,
     this.textInputAction = TextInputAction.newline,
     this.enableScribble = false,
+    this.enableScribbleRichGestures = false,
     this.onScribbleActivated,
     this.scribbleAreaInsets,
     this.readOnlyMouseCursor = SystemMouseCursors.text,
@@ -462,6 +463,19 @@ class QuillEditorConfig {
   /// Enable Scribble? Currently Apple Pencil only, defaults to false.
   final bool enableScribble;
 
+  /// Enable rich Scribble editing gestures (scratch-to-delete, circle-to-select).
+  ///
+  /// When enabled, uses DeltaTextInputClient for granular text editing operations
+  /// from iOS Scribble. This enables advanced Apple Pencil gestures like:
+  /// - Scratch/strike through text to delete
+  /// - Circle text to select
+  /// - Vertical line to insert space
+  /// - Join gesture to remove space
+  ///
+  /// Requires [enableScribble] to be true. Only works on iOS/iPadOS.
+  /// Defaults to false for backward compatibility.
+  final bool enableScribbleRichGestures;
+
   /// Called when Scribble is activated.
   final void Function()? onScribbleActivated;
 
@@ -528,6 +542,7 @@ class QuillEditorConfig {
     bool? requestKeyboardFocusOnCheckListChanged,
     TextInputAction? textInputAction,
     bool? enableScribble,
+    bool? enableScribbleRichGestures,
     void Function()? onScribbleActivated,
     EdgeInsets? scribbleAreaInsets,
     void Function(TextInputAction action)? onPerformAction,
@@ -597,6 +612,8 @@ class QuillEditorConfig {
               this.requestKeyboardFocusOnCheckListChanged,
       textInputAction: textInputAction ?? this.textInputAction,
       enableScribble: enableScribble ?? this.enableScribble,
+      enableScribbleRichGestures:
+          enableScribbleRichGestures ?? this.enableScribbleRichGestures,
       onScribbleActivated: onScribbleActivated ?? this.onScribbleActivated,
       scribbleAreaInsets: scribbleAreaInsets ?? this.scribbleAreaInsets,
       onPerformAction: onPerformAction ?? this.onPerformAction,

--- a/lib/src/editor/editor.dart
+++ b/lib/src/editor/editor.dart
@@ -322,6 +322,7 @@ class QuillEditorState extends State<QuillEditor>
         dialogTheme: config.dialogTheme,
         contentInsertionConfiguration: config.contentInsertionConfiguration,
         enableScribble: config.enableScribble,
+        enableScribbleRichGestures: config.enableScribbleRichGestures,
         onScribbleActivated: config.onScribbleActivated,
         scribbleAreaInsets: config.scribbleAreaInsets,
         readOnlyMouseCursor: config.readOnlyMouseCursor,

--- a/lib/src/editor/raw_editor/config/raw_editor_config.dart
+++ b/lib/src/editor/raw_editor/config/raw_editor_config.dart
@@ -66,6 +66,7 @@ class QuillRawEditorConfig {
     this.textInputAction = TextInputAction.newline,
     this.requestKeyboardFocusOnCheckListChanged = false,
     this.enableScribble = false,
+    this.enableScribbleRichGestures = false,
     this.onScribbleActivated,
     this.scribbleAreaInsets,
     this.readOnlyMouseCursor = SystemMouseCursors.text,
@@ -401,6 +402,19 @@ class QuillRawEditorConfig {
 
   /// Enable Scribble? Currently Apple Pencil only, defaults to false.
   final bool enableScribble;
+
+  /// Enable rich Scribble editing gestures (scratch-to-delete, circle-to-select).
+  ///
+  /// When enabled, uses DeltaTextInputClient for granular text editing operations
+  /// from iOS Scribble. This enables advanced Apple Pencil gestures like:
+  /// - Scratch/strike through text to delete
+  /// - Circle text to select
+  /// - Vertical line to insert space
+  /// - Join gesture to remove space
+  ///
+  /// Requires [enableScribble] to be true. Only works on iOS/iPadOS.
+  /// Defaults to false for backward compatibility.
+  final bool enableScribbleRichGestures;
 
   /// Called when Scribble is activated.
   final void Function()? onScribbleActivated;

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -13,7 +13,7 @@ import '../editor.dart';
 import 'raw_editor.dart';
 
 mixin RawEditorStateTextInputClientMixin on EditorState
-    implements TextInputClient {
+    implements TextInputClient, DeltaTextInputClient {
   TextInputConnection? _textInputConnection;
   TextEditingValue? __lastKnownRemoteTextEditingValue;
 
@@ -92,6 +92,9 @@ mixin RawEditorStateTextInputClientMixin on EditorState
               ? const <String>[]
               : widget.config.contentInsertionConfiguration!.allowedMimeTypes,
           viewId: context.getViewId(),
+          // Enable delta model for rich Scribble gestures (scratch-to-delete, circle-to-select)
+          enableDeltaModel: widget.config.enableScribble &&
+              widget.config.enableScribbleRichGestures,
         ),
       );
 
@@ -244,6 +247,62 @@ mixin RawEditorStateTextInputClientMixin on EditorState
         value.selection,
       );
     }
+  }
+
+  @override
+  void updateEditingValueWithDeltas(List<TextEditingDelta> textEditingDeltas) {
+    if (!shouldCreateInputConnection) {
+      return;
+    }
+
+    // Apply all deltas sequentially to build the final TextEditingValue
+    TextEditingValue value = _lastKnownRemoteTextEditingValue!;
+
+    for (final delta in textEditingDeltas) {
+      value = delta.apply(value);
+    }
+
+    // Check if the final value is the same as the last known value
+    if (_lastKnownRemoteTextEditingValue == value) {
+      return;
+    }
+
+    // Process each delta for granular updates to the Quill document
+    for (final delta in textEditingDeltas) {
+      if (delta is TextEditingDeltaInsertion) {
+        // Handle insertion
+        widget.controller.replaceText(
+          delta.insertionOffset,
+          0, // No deletion
+          delta.textInserted,
+          delta.selection,
+        );
+      } else if (delta is TextEditingDeltaDeletion) {
+        // Handle deletion
+        widget.controller.replaceText(
+          delta.deletedRange.start,
+          delta.deletedRange.end - delta.deletedRange.start,
+          '', // No insertion
+          delta.selection,
+        );
+      } else if (delta is TextEditingDeltaReplacement) {
+        // Handle replacement
+        widget.controller.replaceText(
+          delta.replacedRange.start,
+          delta.replacedRange.end - delta.replacedRange.start,
+          delta.textReplaced,
+          delta.selection,
+        );
+      } else if (delta is TextEditingDeltaNonTextUpdate) {
+        // Handle selection/composing changes only
+        if (delta.selection != _lastKnownRemoteTextEditingValue!.selection) {
+          widget.controller.updateSelection(delta.selection, ChangeSource.local);
+        }
+      }
+    }
+
+    // Update the last known value with the final composing range
+    _lastKnownRemoteTextEditingValue = value;
   }
 
   @override

--- a/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
+++ b/lib/src/editor/raw_editor/raw_editor_state_text_input_client_mixin.dart
@@ -256,7 +256,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
     }
 
     // Apply all deltas sequentially to build the final TextEditingValue
-    TextEditingValue value = _lastKnownRemoteTextEditingValue!;
+    var value = _lastKnownRemoteTextEditingValue!;
 
     for (final delta in textEditingDeltas) {
       value = delta.apply(value);


### PR DESCRIPTION
Implement DeltaTextInputClient to enable advanced Apple Pencil Scribble
editing gestures on iOS/iPadOS, including:
- Scratch/strike through text to delete
- Circle text to select
- Vertical line to insert space
- Join gesture to remove space

Changes:
- Add `enableScribbleRichGestures` configuration option to QuillEditorConfig
  and QuillRawEditorConfig (defaults to false for backward compatibility)
- Implement DeltaTextInputClient mixin in RawEditorStateTextInputClientMixin
- Add updateEditingValueWithDeltas method to handle granular text editing deltas
- Enable TextInputConfiguration.enableDeltaModel when rich gestures are enabled
- Process TextEditingDeltaInsertion, TextEditingDeltaDeletion,
  TextEditingDeltaReplacement, and TextEditingDeltaNonTextUpdate

The feature is opt-in and requires both enableScribble and
enableScribbleRichGestures to be true. Falls back to standard
updateEditingValue for platforms/scenarios that don't support deltas.